### PR TITLE
change dependabot to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "lockFileMaintenance": {
+    "enabled": true
+  }
+}
+


### PR DESCRIPTION
## About

I quit to use Dependabot and replaced it to renovate because dependabot do not support uv.

## Reference

https://docs.astral.sh/uv/guides/integration/dependency-bots/#renovate