### PR TITLE
feature: add dependabot for the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "pydantic"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "lockFileMaintenance": {
-    "enabled": true
-  }
-}
-


### PR DESCRIPTION
## About

in March 13th, dependabot starts to support uv lockfile. I added setting for this project.

https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/


## Implementation

added `.github/dependabot.yml` and remove `renovate.json`